### PR TITLE
#165592284 Delete report, Username case sensitivity

### DIFF
--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -24,8 +24,8 @@ class RegistrationSerializer(serializers.ModelSerializer):
     )
 
     alphanumericusername = RegexValidator(
-        r'^[a-zA-Z][0-9a-zA-Z_]*$',
-        """Ensure username has alphanumerics and underscore only.
+        r'^[a-zA-Z][0-9a-z_]*$',
+        """Ensure username has lowercase alphanumerics and underscore only.
         Username cannot begin with underscore or integer""")
     username = serializers.CharField(
         max_length=27,

--- a/authors/apps/authentication/tests/basetest.py
+++ b/authors/apps/authentication/tests/basetest.py
@@ -13,7 +13,7 @@ class BaseTestCase(APITestCase):
         self.user_1 = {
             "user": {
                 "email": "premiermember@gmail.com",
-                "username": "PremierMember",
+                "username": "premiermember",
                 "password": "premiermember2019"
             }
         }

--- a/authors/apps/authentication/tests/test_login.py
+++ b/authors/apps/authentication/tests/test_login.py
@@ -13,7 +13,7 @@ class RegistrationTestCase(APITestCase):
         self.user_1 = {
             "user": {
                 "email": "premiermember@gmail.com",
-                "username": "PremierMember",
+                "username": "premiermember",
                 "password": "premiermember2019"
             }
         }

--- a/authors/apps/authentication/tests/test_mail.py
+++ b/authors/apps/authentication/tests/test_mail.py
@@ -13,7 +13,7 @@ class EmailRegistrationTestCase(APITestCase):
         self.user_1 = {
             "user": {
                 "email": "newmember@gmail.com",
-                "username": "New_Member",
+                "username": "new_member",
                 "password": "newmember000"
             }
         }

--- a/authors/apps/authentication/tests/test_signup.py
+++ b/authors/apps/authentication/tests/test_signup.py
@@ -12,14 +12,14 @@ class RegistrationTestCase(APITestCase):
         self.user_1 = {
             "user": {
                 "email": "premiermember@gmail.com",
-                "username": "PremierMember",
+                "username": "premiermember",
                 "password": "premiermember2019"
             }
         }
         self.duplicate_user1email = {
             "user": {
                 "email": "premiermember@gmail.com",
-                "username": "Premier_Member_2",
+                "username": "premier_member_2",
                 "password": "premiermember2019"
             }
         }
@@ -27,14 +27,14 @@ class RegistrationTestCase(APITestCase):
         self.duplicate_user1username = {
             "user": {
                 "email": "premiermember2@gmail.com",
-                "username": "PremierMember",
+                "username": "premiermember",
                 "password": "premiermember2019"
             }
         }
 
         self.missing_email = {
             "user": {
-                "username": "Premier_Member",
+                "username": "premier_member",
                 "password": "premiermember2019"
             }
         }
@@ -211,5 +211,5 @@ class RegistrationTestCase(APITestCase):
                          status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             json.loads(res.content)["errors"]["username"],
-            ["""Ensure username has alphanumerics and underscore only.
+            ["""Ensure username has lowercase alphanumerics and underscore only.
         Username cannot begin with underscore or integer"""])

--- a/authors/apps/authentication/tests/test_users.py
+++ b/authors/apps/authentication/tests/test_users.py
@@ -12,14 +12,14 @@ class UserListTestCase(APITestCase):
         self.user_1 = {
             "user": {
                 "email": "premiermember@gmail.com",
-                "username": "PremierMember",
+                "username": "premiermember",
                 "password": "premiermember2019"
             }
         }
         self.user_2 = {
             "user": {
                 "email": "premiermember2@gmail.com",
-                "username": "PremierMember2",
+                "username": "premiermember2",
                 "password": "premiermember2019"
             }
         }
@@ -40,7 +40,7 @@ class UserListTestCase(APITestCase):
         self.assertEqual(user_list.status_code, status.HTTP_200_OK)
         self.assertEqual(data, json.loads(
             """[{"email":"premiermember@gmail.com",
-                "username":"PremierMember", "bio": "", "image": ""}
+                "username":"premiermember", "bio": "", "image": ""}
                 ]
             """))
 

--- a/authors/apps/bookmarks/tests/test_bookmark.py
+++ b/authors/apps/bookmarks/tests/test_bookmark.py
@@ -12,7 +12,7 @@ class BookmarkTestCase(APITestCase):
         self.user_1 = {
             "user": {
                 "email": "premiermember@gmail.com",
-                "username": "PremierMember",
+                "username": "premiermember",
                 "password": "premiermember2019"
             }
         }

--- a/authors/apps/bookmarks/tests/test_unbookmark.py
+++ b/authors/apps/bookmarks/tests/test_unbookmark.py
@@ -12,7 +12,7 @@ class UnBookmarkTestCase(APITestCase):
         self.user_1 = {
             "user": {
                 "email": "premiermember@gmail.com",
-                "username": "PremierMember",
+                "username": "premiermember",
                 "password": "premiermember2019"
             }
         }

--- a/authors/apps/bookmarks/tests/test_view_bookmarks.py
+++ b/authors/apps/bookmarks/tests/test_view_bookmarks.py
@@ -13,7 +13,7 @@ class BookmarkTestCase(APITestCase):
         self.user_1 = {
             "user": {
                 "email": "premiermember@gmail.com",
-                "username": "PremierMember",
+                "username": "premiermember",
                 "password": "premiermember2019"
             }
         }
@@ -68,7 +68,7 @@ class BookmarkTestCase(APITestCase):
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertIn('bookmarkers', res.data)
         self.assertEqual(json.loads(res.content)["bookmarkers"][0][
-                         "profile"]["username"], "PremierMember")
+                         "profile"]["username"], "premiermember")
 
     def test_view_bookmarkers_on_non_existent_article(self):
         res = self.client.get(

--- a/authors/apps/notifications/tests/test_sending_notifs.py
+++ b/authors/apps/notifications/tests/test_sending_notifs.py
@@ -26,7 +26,7 @@ class EmailTest(APITestCase):
         user_1 = {
             "user": {
                 "email": "premiermember@gmail.com",
-                "username": "PremierMember",
+                "username": "premiermember",
                 "password": "premiermember2019"
             }
         }
@@ -63,7 +63,7 @@ class EmailTest(APITestCase):
         self.signupuser2()
         self.client.post(
             self.followuser_url.format(
-                "PremierMember"),
+                "premiermember"),
             HTTP_AUTHORIZATION='bearer {}'.format(self.token2),
             format="json")
 
@@ -117,7 +117,7 @@ class EmailTest(APITestCase):
         # and the new
         # email that is to be sent pertaining the new article.
         self.assertEqual(len(mail.outbox), 4)
-        self.assertEqual(mail.outbox[3].subject, "PremierMember's New Article")
+        self.assertEqual(mail.outbox[3].subject, "premiermember's New Article")
 
     def test_if_notification_will_be_sent_via_email_on_unsubscribing(self):
         self.user2followuser1()

--- a/authors/apps/notifications/tests/test_subscription.py
+++ b/authors/apps/notifications/tests/test_subscription.py
@@ -12,7 +12,7 @@ class OptInTestCase(APITestCase):
         self.user_1 = {
             "user": {
                 "email": "premiermember@gmail.com",
-                "username": "PremierMember",
+                "username": "premiermember",
                 "password": "premiermember2019"
             }
         }

--- a/authors/apps/profiles/tests/test_all_profiles.py
+++ b/authors/apps/profiles/tests/test_all_profiles.py
@@ -38,7 +38,7 @@ class RegistrationTestCase(BaseTestCase):
         first_alphabet = {
             "user": {
                 "email": "acemember@gmail.com",
-                "username": "Ace_Member",
+                "username": "ace_member",
                 "password": "acemember2019"
             }
         }
@@ -50,6 +50,6 @@ class RegistrationTestCase(BaseTestCase):
             format="json")
         self.assertEqual(profiles.status_code, status.HTTP_200_OK)
         self.assertEqual(json.loads(profiles.content)[
-                         0]["username"], "Ace_Member")
+                         0]["username"], "ace_member")
         self.assertEqual(json.loads(profiles.content)[
-                         1]["username"], "PremierMember")
+                         1]["username"], "premiermember")

--- a/authors/apps/profiles/tests/test_follow.py
+++ b/authors/apps/profiles/tests/test_follow.py
@@ -15,7 +15,7 @@ class RegistrationTestCase(APITestCase):
         self.user_1 = {
             "user": {
                 "email": "premiermember@gmail.com",
-                "username": "PremierMember",
+                "username": "premiermember",
                 "password": "premiermember2019"
             }
         }
@@ -28,7 +28,7 @@ class RegistrationTestCase(APITestCase):
         user_to_follow = {
             "user": {
                 "email": "premiermember2@gmail.com",
-                "username": "PremierMember2",
+                "username": "premiermember2",
                 "password": "premiermember2019"
             }
         }
@@ -65,7 +65,7 @@ class RegistrationTestCase(APITestCase):
         self.assertEqual(json.loads(res.content),
                          {
             "followers": [{
-                "username": "PremierMember2",
+                "username": "premiermember2",
                 "firstname": "",
                 "lastname": "",
                 "bio": "",
@@ -96,7 +96,7 @@ class RegistrationTestCase(APITestCase):
         self.assertEqual(follow_twice.status_code, status.HTTP_409_CONFLICT)
         self.assertEqual(json.loads(follow_twice.content),
                          {
-            "error": "You follow PremierMember already"
+            "error": "You follow premiermember already"
         })
 
     def test_follow_non_existent_user(self):
@@ -136,7 +136,7 @@ class RegistrationTestCase(APITestCase):
                 "fullname": " ",
                 "lastname": "",
                 "image": "",
-                "username": "PremierMember"
+                "username": "premiermember"
             }]
         })
 

--- a/authors/apps/profiles/tests/test_profile_create_n_retrieve.py
+++ b/authors/apps/profiles/tests/test_profile_create_n_retrieve.py
@@ -13,7 +13,7 @@ class ProfileCreationTestClass(APITestCase):
         self.user_1 = {
             "user": {
                 "email": "premiermember@gmail.com",
-                "username": "PremierMember",
+                "username": "premiermember",
                 "password": "premiermember2019"
             }
         }

--- a/authors/apps/profiles/tests/test_profile_update.py
+++ b/authors/apps/profiles/tests/test_profile_update.py
@@ -44,7 +44,7 @@ class ProfileUpdateClass(BaseTestCase):
         user_2 = {
             "user": {
                 "email": "premiermemberanonymous@gmail.com",
-                "username": "PremierMember_Anonymous",
+                "username": "premiermember_anonymous",
                 "password": "premiermember2019"
             }
         }

--- a/authors/apps/profiles/tests/test_unfollow.py
+++ b/authors/apps/profiles/tests/test_unfollow.py
@@ -15,7 +15,7 @@ class RegistrationTestCase(APITestCase):
         self.user_1 = {
             "user": {
                 "email": "premiermember@gmail.com",
-                "username": "PremierMember",
+                "username": "premiermember",
                 "password": "premiermember2019"
             }
         }
@@ -28,7 +28,7 @@ class RegistrationTestCase(APITestCase):
         user_to_follow = {
             "user": {
                 "email": "premiermember2@gmail.com",
-                "username": "PremierMember2",
+                "username": "premiermember2",
                 "password": "premiermember2019"
             }
         }
@@ -57,7 +57,7 @@ class RegistrationTestCase(APITestCase):
 
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(json.loads(res.content), {
-            "data": "You have successfully unfollowed PremierMember"
+            "data": "You have successfully unfollowed premiermember"
         })
         newres = self.client.get(
             "/api/users/{}/followers/".format(self.user["username"]))
@@ -76,7 +76,7 @@ class RegistrationTestCase(APITestCase):
 
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(json.loads(res.content), {
-            "error": "You had not followed PremierMember so cannot unfollow"
+            "error": "You had not followed premiermember so cannot unfollow"
         })
 
     def test_unfollow_non_existent_user(self):

--- a/authors/apps/reports/tests/test_reports.py
+++ b/authors/apps/reports/tests/test_reports.py
@@ -11,7 +11,6 @@ class ReportArticleTestCase(BaseTestCase):
         self.single_report_url = '/api/articles/report/{report_id}/'
         self.list_reports_url = '/api/articles/report/list/'
         self.flag_article_url = '/api/articles/report/{report_id}/flag/'
-        self.report_action_url = '/api/articles/report/{report_id}/action/'
         self.flagged_articles_url = '/api/articles/report/flag/'
         self.report_article = {
             "report": {
@@ -86,23 +85,6 @@ class ReportArticleTestCase(BaseTestCase):
         self.assertEqual(get_article.status_code,
                          status.HTTP_200_OK)
 
-    def test_delete_report(self):
-        """ test delete report """
-
-        report = self.post_report()
-        report_data = json.loads(report.content)
-        report_id = report_data['report']['id']
-        self.client.credentials()
-        self.client.credentials(
-            HTTP_AUTHORIZATION='Bearer ' + self.admin_credentials
-        )
-        delete_report = self.client.delete(
-            self.report_action_url.format(report_id=report_id)
-        )
-
-        self.assertEqual(delete_report.status_code,
-                         status.HTTP_200_OK)
-
     def test_flag_article(self):
         """ test flag article """
 
@@ -121,6 +103,21 @@ class ReportArticleTestCase(BaseTestCase):
         report_data = json.loads(report.content)
         report_id = report_data['report']['id']
         self.flag_report(report_id)
+        unflag_article = self.client.delete(
+            self.flag_article_url.format(report_id=report_id)
+        )
+
+        self.assertEqual(unflag_article.status_code, status.HTTP_200_OK)
+
+    def test_unflag_unflagged_article(self):
+        """ test unflag unflagged article """
+        report = self.post_report()
+        report_data = json.loads(report.content)
+        report_id = report_data['report']['id']
+        self.client.credentials()
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + self.admin_credentials
+        )
         unflag_article = self.client.delete(
             self.flag_article_url.format(report_id=report_id)
         )

--- a/authors/apps/reports/urls.py
+++ b/authors/apps/reports/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from .views import (ReportArticleView, ListReportView,
-                    ReportsView, ReportActionView, FlagArticleView,
+                    ReportsView, FlagArticleView,
                     FlaggedArticlesView)
 
 urlpatterns = [
@@ -15,9 +15,6 @@ urlpatterns = [
 
     path('articles/report/list/',
          ListReportView.as_view(), name="list-reports"),
-
-    path('articles/report/<int:id>/action/',
-         ReportActionView.as_view(), name="take-action-reports"),
 
     path('articles/report/<int:id>/flag/',
          FlagArticleView.as_view(), name="flag-article"),

--- a/authors/apps/reports/views.py
+++ b/authors/apps/reports/views.py
@@ -65,21 +65,6 @@ class ReportsView(RetrieveAPIView):
         )
 
 
-class ReportActionView(CreateAPIView, DestroyAPIView):
-    permission_classes = (IsAdminUser, )
-    serializer_class = ReportArticleSerializer
-
-    def delete(self, request, id):
-        """ Delete report """
-
-        report = get_object_or_404(ReportArticle, id=id)
-        report.delete()
-        return Response(
-            {"detail": "Report has been deleted".format(id=id)},
-            status=status.HTTP_200_OK
-        )
-
-
 class FlagArticleView(APIView):
 
     permission_classes = (IsAdminUser, )


### PR DESCRIPTION
#### What does this PR do?
- Remove admin delete report feature
- Fix username case sensitivity
#### Description of Task to be completed?
- An admin user should not be able  to delete article reports
- Username should be in lowercase
#### How should this be manually tested?
- Clone the repo
- Navigate to the project directory
- Branch to `ch/165592284-delete-report-username`
- Create and activate a virtual environment
```
$ virtualenv env
$ vsource env/bin/activate
```
- Install requirements
```
$ pip install -r requirements.txt
```
- Make migrations
```
$ python manage.py makemigrations
```
- Run migrations
```
$ python manage.py migrate
```
- Run the server
```
$ python manage.py runserver
```
- Test the endpoints on postman
- Signup user `[POST] /api/users/`
- Required fields
```
{
            "user": {
                "email": "premiermember@gmail.com",
                "username": "premieR",
                "password": "scorpion234"
            }
}
```
- Response
```
{
    "errors": {
        "email": [
            "user with this email already exists."
        ],
        "username": [
            "Ensure username has lowercase alphanumerics and underscore only. Username cannot begin with underscore or integer"
        ]
    }
}
```
- Admin delete report `[DELETE] /api/articles/report/3/action`
- A `404 Not Found` error is returned
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/165592284