### PR TITLE
Add user image to profile list

### DIFF
--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -19,7 +19,7 @@ class ViewAllProfiles(generics.ListAPIView):
     """
     serializer_class = ProfileSerializer
     filter_backends = (SearchFilter, OrderingFilter)
-    search_fields = ('bio', 'user__email', 'user__username')
+    search_fields = ('bio', 'user__email', 'user__username', 'image')
     ordering_fields = ('bio', 'user__username')
     queryset = Profile.objects.all()
 


### PR DESCRIPTION
### Title
Add user image to the user search field


What does this PR do?
This PR adds the user image as a property when searching for a user. This wasn't present before but is now possible
![image](https://user-images.githubusercontent.com/12128153/61622916-66ad4900-ac7e-11e9-980b-e12c0f57a17e.png)


### Checklist

- [x] - add an image params being returned in the list of profiles.